### PR TITLE
请升级com.alibaba:druid组件版本以解决1个安全漏洞

### DIFF
--- a/javaframework/mybatis/04mybatis的基本使用3/ssm/pom.xml
+++ b/javaframework/mybatis/04mybatis的基本使用3/ssm/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/mybatis/05mybatis-plus/mybatis_plus_helloworld/pom.xml
+++ b/javaframework/mybatis/05mybatis-plus/mybatis_plus_helloworld/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/mybatis/06mybatis-plus2/mybatis_plus_generator/pom.xml
+++ b/javaframework/mybatis/06mybatis-plus2/mybatis_plus_generator/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/mybatis/06mybatis-plus2/mybatis_plus_helloworld/pom.xml
+++ b/javaframework/mybatis/06mybatis-plus2/mybatis_plus_helloworld/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/spring/03springIOC容器的配置使用2/spring_study2/pom.xml
+++ b/javaframework/spring/03springIOC容器的配置使用2/spring_study2/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/spring/07SpringAOP的详细讲解2/spring_aop_tx/pom.xml
+++ b/javaframework/spring/07SpringAOP的详细讲解2/spring_aop_tx/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/spring/08Spring源码讲解/spring_aop_tx/pom.xml
+++ b/javaframework/spring/08Spring源码讲解/spring_aop_tx/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>

--- a/javaframework/spring/09动态代理源码分析/spring_aop_tx/pom.xml
+++ b/javaframework/spring/09动态代理源码分析/spring_aop_tx/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.21</version>
+            <version>1.2.15</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>


### PR DESCRIPTION
将 **com.alibaba:druid** 组件从1.1.21 版本升级至 1.2.15版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2021-25327](https://www.oscs1024.com/hd/MPS-2021-25327) | Alibaba Druid 目录穿越漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
